### PR TITLE
Updated customer kubeconfig file location.

### DIFF
--- a/src/main/groovy/io/cratekube/clustermgmt/service/ManagedResourcesService.groovy
+++ b/src/main/groovy/io/cratekube/clustermgmt/service/ManagedResourcesService.groovy
@@ -148,7 +148,7 @@ class ManagedResourcesService implements ManagedResourcesApi {
     def server = configJson.clusters[0].cluster.server
 
     // write customer kubeconfig to file
-    String customerKubeconfigPath = "${clusterPath}/customer_kubeconfig.yml"
+    String customerKubeconfigPath = "${clusterPath}/customer_kube_config.yml"
     log.debug 'Writing customer kubeconfig to [{}]', customerKubeconfigPath
     def customerKubeconfigYml = fs.resolveFile(customerKubeconfigPath)
     def template = handlebars.compile('customer-kubeconfig.yaml')

--- a/src/test/groovy/io/cratekube/clustermgmt/service/ManagedResourcesServiceSpec.groovy
+++ b/src/test/groovy/io/cratekube/clustermgmt/service/ManagedResourcesServiceSpec.groovy
@@ -122,7 +122,7 @@ class ManagedResourcesServiceSpec extends Specification {
     }
 
     // mock for handlebars templateing calls to create customer kubeconfig
-    String customerKubeconfig = "${config.configLocation}/environment/${environmentNm}/cluster/${clusterNm}/customer_kubeconfig.yml"
+    String customerKubeconfig = "${config.configLocation}/environment/${environmentNm}/cluster/${clusterNm}/customer_kube_config.yml"
     fs.resolveFile(customerKubeconfig) >> Mock(FileObject) {
       getContent() >> Mock(FileContent) {
         getOutputStream() >> GroovyMock(OutputStream)


### PR DESCRIPTION
Signed-off-by: Daniel Foglio <dfoglio@cisco.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cratekube/cluster-mgmt-service/10)
<!-- Reviewable:end -->
